### PR TITLE
Specify C99 standard in make file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
 iris-floss: iris-floss.c
-	gcc -Wall -o iris-floss iris-floss.c -lX11 -lXrandr
+	gcc -Wall -std=c99 -o iris-floss iris-floss.c -lX11 -lXrandr


### PR DESCRIPTION
Declaration of loop variables in the loop declaration requires C99.